### PR TITLE
Generic keys and value-type data

### DIFF
--- a/LruCacheNet/LruCache.cs
+++ b/LruCacheNet/LruCache.cs
@@ -11,7 +11,7 @@ namespace LruCacheNet
     /// <summary>
     /// An LRU cache that caches data in memory 
     /// </summary>
-    /// <typeparam name="K">Typ of key to use</typeparam>
+    /// <typeparam name="K">Type of key to use</typeparam>
     /// <typeparam name="T">Type of data to store in the cache</typeparam>
     public class LruCache<K, T>
     {
@@ -37,12 +37,13 @@ namespace LruCacheNet
         /// Initializes a new instance of the <see cref="LruCache{K,T}"/> class with a specific cache size
         /// </summary>
         /// <param name="capacity">Maximum number of items to hold in the cache</param>
+        /// <exception cref="ArgumentException">Thrown if the capacity is less than the minimum</exception>
         public LruCache(int capacity)
         {
             // Why would you have a cache with so few items?
             if (capacity < MinimumCacheSize)
             {
-                throw new ArgumentException("Cache size must be at least 3", nameof(capacity));
+                throw new ArgumentException("Cache size must be at least 2", nameof(capacity));
             }
 
             _cacheSize = capacity;
@@ -111,6 +112,7 @@ namespace LruCacheNet
         /// </summary>
         /// <param name="key">Key to store in the cache</param>
         /// <param name="data">Data to cache</param>
+        /// <exception cref="ArgumentException">Thrown if the key or data is null</exception>
         public void AddOrUpdate(K key, T data)
         {
             if (key == null)
@@ -168,6 +170,7 @@ namespace LruCacheNet
         /// </summary>
         /// <param name="key">Key to find in the cache</param>
         /// <returns>Cached data, null if not found</returns>
+        /// <exception cref="KeyNotFoundException">Thrown if the key is not found in the cache</exception>
         public T Get(K key)
         {
             lock (_lock)
@@ -210,6 +213,7 @@ namespace LruCacheNet
         /// </summary>
         /// <param name="key">Key for the item to remove</param>
         /// <returns>Data that was stored in the cache, null if none</returns>
+        /// <exception cref="KeyNotFoundException">Thrown if the key is not found in the cache</exception>
         public T Remove(K key)
         {
             lock (_lock)
@@ -244,6 +248,7 @@ namespace LruCacheNet
         /// </summary>
         /// <param name="key">Key for which to search the queue</param>
         /// <returns>Item for key if found, otherwise null</returns>
+        /// <exception cref="KeyNotFoundException">Thrown if the key is not found in the cache</exception>
         public T Peek(K key)
         {
             lock (_lock)

--- a/LruCacheNet/Node.cs
+++ b/LruCacheNet/Node.cs
@@ -10,21 +10,22 @@ namespace LruCacheNet
     /// <summary>
     /// Node for storing data in the doubly linked list
     /// </summary>
+    /// <typeparam name="K">Type of key to use to identify the data</typeparam>
     /// <typeparam name="T">Type of data to store in the cache</typeparam>
-    public sealed class Node<T>
+    public sealed class Node<K, T>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Node{T}"/> class
+        /// Initializes a new instance of the <see cref="Node{K,T}"/> class
         /// </summary>
         /// <param name="key">Key for the node</param>
         /// <param name="data">Data for the node</param>
 #if DEBUG
-        public Node(string key, T data)
+        public Node(K key, T data)
 #else
-        internal Node(string key, T data)
+        internal Node(K key, T data)
 #endif
         {
-            if (string.IsNullOrEmpty(key))
+            if (key == null)
             {
                 throw new ArgumentException("Key cannot be null", nameof(key));
             }
@@ -47,24 +48,24 @@ namespace LruCacheNet
         /// <summary>
         /// Gets or sets the key for the data in the cache
         /// </summary>
-        public string Key { get; set; }
+        public K Key { get; set; }
 
         /// <summary>
         /// Gets or sets the next node in the list
         /// </summary>
-        public Node<T> Next { get; set; }
+        public Node<K, T> Next { get; set; }
 
         /// <summary>
         /// Gets or sets the previous node in the list
         /// </summary>
-        public Node<T> Previous { get; set; }
+        public Node<K, T> Previous { get; set; }
 
         public override string ToString()
         {
             return $"Key:{Key} Data:{Data.ToString()} Previous:{GetNodeSummary(Previous)} Next:{GetNodeSummary(Next)}";
         }
 
-        private string GetNodeSummary(Node<T> node)
+        private string GetNodeSummary(Node<K, T> node)
         {
             return node != null ? "Set" : "Null";
         }

--- a/UnitTests/NodeTests.cs
+++ b/UnitTests/NodeTests.cs
@@ -18,7 +18,7 @@ namespace UnitTests
             bool thrown = false;
             try
             {
-                var node = new Node<TestData>(null, new TestData());
+                var node = new Node<string, TestData>(null, new TestData());
             }
             catch (ArgumentException)
             {
@@ -33,7 +33,7 @@ namespace UnitTests
             bool thrown = false;
             try
             {
-                var node = new Node<TestData>("0", null);
+                var node = new Node<string, TestData>("0", null);
             }
             catch (ArgumentException)
             {
@@ -49,14 +49,14 @@ namespace UnitTests
         [DataRow(true, true, "Key:0 Data:0 Previous:Set Next:Set", DisplayName = "True|True")]
         public void NodeToString(bool setPrevious, bool setNext, string expected)
         {
-            var node = new Node<string>("0", "0");
+            var node = new Node<string, string>("0", "0");
             if (setPrevious)
             {
-                node.Previous = new Node<string>("1", "1");
+                node.Previous = new Node<string, string>("1", "1");
             }
             if (setNext)
             {
-                node.Next = new Node<string>("2", "2");
+                node.Next = new Node<string, string>("2", "2");
             }
             string str = node.ToString();
             Assert.AreEqual(expected, str);

--- a/UnitTests/TestData.cs
+++ b/UnitTests/TestData.cs
@@ -11,4 +11,4 @@ namespace UnitTests
 
         public string TestValue2 { get; set; }
     }
-}
+}f

--- a/UnitTests/TestData.cs
+++ b/UnitTests/TestData.cs
@@ -11,4 +11,4 @@ namespace UnitTests
 
         public string TestValue2 { get; set; }
     }
-}f
+}


### PR DESCRIPTION
- Use a generic value for the key rather than a string
- Allow value types to be the data type
- Fix a bug moving items to the front from the tail